### PR TITLE
BUGFIX: Process all colliders

### DIFF
--- a/Source/Game/Engine/Physics/Physics.cpp
+++ b/Source/Game/Engine/Physics/Physics.cpp
@@ -30,7 +30,7 @@ void Physics::Update()
 		auto& lhs = m_colliders[i];
 		if (!lhs->m_bEnabled)
 		{
-			return;
+			continue;
 		}
 		for (size_t j = i + 1; j < m_colliders.size(); ++j)
 		{


### PR DESCRIPTION
* `Physics::Update()` would incorrectly `return` instead of
`continue`-ing after encountering a disabled collider.

# Description

Close #25

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Any code I have modified/added conforms to the [Coding Standard](https://github.com/karnkaul/MicroEngine/wiki/Coding-Standards)
- [x] I have run `Tools/clang-format.sh`
- [x] My changes generate no new warnings
- [x] The project builds and runs without any issues
- [x] Any dependent changes have been merged and published in downstream modules
